### PR TITLE
Actually utilize storyblok's cache & handle invalidation

### DIFF
--- a/src/server/utils/storyblok.ts
+++ b/src/server/utils/storyblok.ts
@@ -1,6 +1,15 @@
 import axios from 'axios'
 import { BodyStory } from '../../storyblok/StoryContainer'
 import { config } from '../config'
+import { appLogger } from '../logging'
+
+let remoteCacheVersion = new Date()
+const getRemoteCacheVersionTimestamp = () =>
+  String(Math.round(Number(remoteCacheVersion) / 1000))
+setTimeout(() => {
+  appLogger.info('Updating remote cache version')
+  remoteCacheVersion = new Date()
+}, 60 * 15 * 1000)
 
 const apiClient = axios.create({
   baseURL: 'https://api.storyblok.com',
@@ -14,10 +23,7 @@ export const getPublishedStoryFromSlug = (
     params: {
       token: config.storyblokApiToken,
       find_by: 'slug',
-      cv: cacheVersion,
-    },
-    headers: {
-      'cache-control': 'no-cache',
+      cv: cacheVersion || getRemoteCacheVersionTimestamp(),
     },
   })
 
@@ -27,7 +33,7 @@ export const getDraftedStoryById = (id: string, cacheVersion: string) =>
       token: config.storyblokApiToken,
       find_by: 'id',
       version: 'draft',
-      cv: cacheVersion,
+      cv: cacheVersion || getRemoteCacheVersionTimestamp(),
     },
     headers: {
       'cache-control': 'no-cache',


### PR DESCRIPTION
When playing around with storyblok on a private project this weekend i realized they cache things _very_ hard unless you pass this timestamp. This is a proposal of how to solve the super-hard caching they do, but still utilise it.

Storing the cv in-memory could cause inconsistencies with the load balancer, but i think we can live with that? In the worst possible scenarion the end user would se inconsistent content for a few minutes if moving back and forth between pages. Maybe if we implement some caching on our side we'll utilise some redis or something to do this properly, but i'm fine with this as of now. What do you say?