### PR TITLE
Partner & code cookies

### DIFF
--- a/src/server/entry.tsx
+++ b/src/server/entry.tsx
@@ -11,7 +11,10 @@ import { config } from './config'
 import { helmetConfig } from './config/helmetConfig'
 import { sentryConfig } from './config/sentry'
 import { appLogger } from './logging'
-import { inCaseOfEmergency } from './middlewares/enhancers'
+import {
+  inCaseOfEmergency,
+  savePartnershipCookie,
+} from './middlewares/enhancers'
 import { forceHost } from './middlewares/redirects'
 import {
   addBlogPostsToState,
@@ -78,6 +81,7 @@ const server = createKoaServer({
 if (config.forceHost) {
   server.router.use('/*', forceHost({ host: config.forceHost }))
 }
+server.router.use('/*', savePartnershipCookie)
 server.router.use('/*', removeTrailingSlashes())
 redirects.forEach(([source, target, code]) => {
   server.router.get(source, (ctx) => {

--- a/src/server/middlewares/enhancers.ts
+++ b/src/server/middlewares/enhancers.ts
@@ -63,8 +63,18 @@ export const savePartnershipCookie: Middleware = async (ctx, next) => {
     ctx.cookies.set('_hvpartner', ctx.query.partner.toLowerCase(), {
       httpOnly: false,
       path: '/',
+      signed: false,
     })
   }
+
+  if (ctx.query.code) {
+    ctx.cookies.set('_hvcode', ctx.query.code.toLowerCase(), {
+      httpOnly: false,
+      path: '/',
+      signed: false,
+    })
+  }
+
 
   await next()
 }

--- a/src/server/middlewares/enhancers.ts
+++ b/src/server/middlewares/enhancers.ts
@@ -57,3 +57,14 @@ export const nextWithSentry: Middleware = async (ctx, next) => {
     throw e
   }
 }
+
+export const savePartnershipCookie: Middleware = async (ctx, next) => {
+  if (ctx.query.partner) {
+    ctx.cookies.set('_hvpartner', ctx.query.partner.toLowerCase(), {
+      httpOnly: false,
+      path: '/',
+    })
+  }
+
+  await next()
+}

--- a/src/server/middlewares/enhancers.ts
+++ b/src/server/middlewares/enhancers.ts
@@ -75,6 +75,5 @@ export const savePartnershipCookie: Middleware = async (ctx, next) => {
     })
   }
 
-
   await next()
 }


### PR DESCRIPTION
Allows us to set partner + code already on the web. Used in combination with HedvigInsurance/web-onboarding#142