### PR TITLE
Fix missing metadata

### DIFF
--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -88,7 +88,30 @@ export const getMeta = ({ story, title, nonce = '', fullSlug }: Meta) => (
         content={getStoryblokImage(story.content.seo_meta_og_image)}
       />
     )}
+    <meta
+      property="og:url"
+      content={`${getPublicHost()}/${fullSlug || getFullSlugFromStory(story)}`}
+    />
+    {story && story.content.seo_meta_og_title && (
+      <meta
+        property="twitter:title"
+        content={story.content.seo_meta_og_title}
+      />
+    )}
+    {story && story.content.seo_meta_og_description && (
+      <meta
+        property="twitter:description"
+        content={story.content.seo_meta_og_description}
+      />
+    )}
+    {story && story.content.seo_meta_og_image && (
+      <meta
+        property="twitter:image"
+        content={story.content.seo_meta_og_image}
+      />
+    )}
     <meta name="twitter:site" content="@hedvigapp" />
+    <meta name="twitter:card" content="summary_large_image" />
     <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <meta name="theme-color" content="#651eff" />
   </>

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -93,22 +93,16 @@ export const getMeta = ({ story, title, nonce = '', fullSlug }: Meta) => (
       content={`${getPublicHost()}/${fullSlug || getFullSlugFromStory(story)}`}
     />
     {story && story.content.seo_meta_og_title && (
-      <meta
-        property="twitter:title"
-        content={story.content.seo_meta_og_title}
-      />
+      <meta name="twitter:title" content={story.content.seo_meta_og_title} />
     )}
     {story && story.content.seo_meta_og_description && (
       <meta
-        property="twitter:description"
+        name="twitter:description"
         content={story.content.seo_meta_og_description}
       />
     )}
     {story && story.content.seo_meta_og_image && (
-      <meta
-        property="twitter:image"
-        content={story.content.seo_meta_og_image}
-      />
+      <meta name="twitter:image" content={story.content.seo_meta_og_image} />
     )}
     <meta name="twitter:site" content="@hedvigapp" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -59,7 +59,7 @@ export const getMeta = ({ story, title, nonce = '', fullSlug }: Meta) => (
     <title>{title ? title : getPageTitleFromStory(story)}</title>
     <link
       rel="canonical"
-      href={`${getPublicHost()}/${fullSlug || getFullSlugFromStory(story)}`}
+      href={`${getPublicHost()}${fullSlug || getFullSlugFromStory(story)}`}
     />
     {story && story.content.robots && (
       <meta
@@ -90,7 +90,7 @@ export const getMeta = ({ story, title, nonce = '', fullSlug }: Meta) => (
     )}
     <meta
       property="og:url"
-      content={`${getPublicHost()}/${fullSlug || getFullSlugFromStory(story)}`}
+      content={`${getPublicHost()}${fullSlug || getFullSlugFromStory(story)}`}
     />
     {story && story.content.seo_meta_og_title && (
       <meta name="twitter:title" content={story.content.seo_meta_og_title} />


### PR DESCRIPTION
- Added the mandatory `og:url` meta tag
- Provided some mandatory twitter tags (used the OG content)
- Removed an unwanted extra `/` from both `canonical` and `og:url`