### PR TITLE
Fix 404 when editing blog posts

### DIFF
--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -184,7 +184,7 @@ export const BlogPostPage: React.FunctionComponent<{ nonce?: string }> = ({
 
           <BlogPostsContainer>
             {({ blogPosts }) => {
-              const index = blogPosts.findIndex(({ id }) => id === story.id)
+              const index = blogPosts && blogPosts.findIndex(({ id }) => id === story.id)
               return (
                 <PrevNextSection>
                   <PrevNextWrapper>

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -184,7 +184,8 @@ export const BlogPostPage: React.FunctionComponent<{ nonce?: string }> = ({
 
           <BlogPostsContainer>
             {({ blogPosts }) => {
-              const index = blogPosts && blogPosts.findIndex(({ id }) => id === story.id)
+              const index =
+                blogPosts && blogPosts.findIndex(({ id }) => id === story.id)
               return (
                 <PrevNextSection>
                   <PrevNextWrapper>


### PR DESCRIPTION
When editing a blog post in Storyblok the preview shows a 404-page. This was due to a runtime error regarding calling the function `findIndex` on an `undefined` object.