### PR TITLE
Extend video support

### DIFF
--- a/src/blocks/ImageTextBlock/BackgroundVideo.tsx
+++ b/src/blocks/ImageTextBlock/BackgroundVideo.tsx
@@ -47,8 +47,6 @@ const VideoWrapper = styled('div')({
 })
 
 interface PlayerProps {
-  videoRef: React.RefObject<HTMLVideoElement>
-  mobileVideoRef: React.RefObject<HTMLVideoElement>
   baseMobileVideoUrl: string
   baseVideoUrl: string
   desktopImage: string
@@ -57,21 +55,15 @@ interface PlayerProps {
 
 interface VideoItemProps {
   videoUrl: string
-  videoRef: React.RefObject<HTMLVideoElement>
 }
 
-const VideoItem: React.FunctionComponent<VideoItemProps> = ({
-  videoUrl,
-  videoRef,
-}) => (
+const VideoItem: React.FunctionComponent<VideoItemProps> = ({ videoUrl }) => (
   <VideoWrapper>
     <DeferredVideo src={videoUrl} />
   </VideoWrapper>
 )
 
 export const BackgroundVideo: React.SFC<PlayerProps & BackgroundProps> = ({
-  videoRef,
-  mobileVideoRef,
   desktopImage,
   mobileImage,
   baseVideoUrl,
@@ -81,14 +73,14 @@ export const BackgroundVideo: React.SFC<PlayerProps & BackgroundProps> = ({
   <HeightContainer backgroundColor={backgroundColor}>
     <MediaQuery query="(max-width: 700px)">
       {baseMobileVideoUrl ? (
-        <VideoItem videoUrl={baseMobileVideoUrl} videoRef={mobileVideoRef} />
+        <VideoItem videoUrl={baseMobileVideoUrl} />
       ) : (
         mobileImage && <BackgroundImage image={mobileImage} />
       )}
     </MediaQuery>
     <MediaQuery query="(min-width: 701px)">
       {baseVideoUrl ? (
-        <VideoItem videoUrl={baseVideoUrl} videoRef={videoRef} />
+        <VideoItem videoUrl={baseVideoUrl} />
       ) : (
         desktopImage && <BackgroundImage image={desktopImage} />
       )}

--- a/src/blocks/ImageTextBlock/BackgroundVideo.tsx
+++ b/src/blocks/ImageTextBlock/BackgroundVideo.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import styled, { keyframes } from 'react-emotion'
+import MediaQuery from 'react-responsive'
+import { backgroundImageStyles } from '../../components/blockHelpers'
+
+interface BackgroundProps {
+  backgroundColor: string
+}
+
+const fadeInKeyframe = keyframes({
+  from: {
+    opacity: 0,
+  },
+  to: {
+    opacity: 1,
+  },
+})
+
+const HeightContainer = styled('div')(
+  ({ backgroundColor }: BackgroundProps) => ({
+    animation: `${fadeInKeyframe} 2000ms forwards`,
+    transition: 'height 1500ms, padding 1500ms',
+    overflow: 'hidden',
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor,
+    position: 'absolute',
+    top: 0,
+    width: '100%',
+    height: '100%',
+  }),
+)
+
+const BackgroundImage = styled('div')(({ image }: { image: string }) => ({
+  height: '100%',
+  overflow: 'hidden',
+  width: '100%',
+  ...backgroundImageStyles(image),
+}))
+
+const VideoWrapper = styled('div')({
+  height: '100%',
+  overflow: 'hidden',
+  width: '100%',
+  position: 'relative',
+})
+
+const Video = styled('video')({
+  width: '100%',
+  objectFit: 'cover',
+  transition: 'height 1500ms',
+  overflow: 'hidden',
+  borderRadius: 0.01,
+  position: 'absolute',
+  bottom: 0,
+  right: 0,
+  left: 0,
+  height: '100%',
+  '@media(min-width: 1500px)': {
+    height: '110vh',
+  },
+})
+
+interface PlayerProps {
+  videoRef: React.RefObject<HTMLVideoElement>
+  mobileVideoRef: React.RefObject<HTMLVideoElement>
+  baseMobileVideoUrl: string
+  baseVideoUrl: string
+  desktopImage: string
+  mobileImage: string
+}
+
+interface VideoItemProps {
+  videoUrl: string
+  videoRef: React.RefObject<HTMLVideoElement>
+}
+
+const VideoItem: React.FunctionComponent<VideoItemProps> = ({
+  videoUrl,
+  videoRef,
+}) => (
+  <VideoWrapper>
+    <Video
+      poster={`${videoUrl}.png`}
+      innerRef={videoRef}
+      playsInline
+      autoPlay
+      muted={true}
+      loop={true}
+      controls={false}
+    >
+      <source src={`${videoUrl}.m3u8`} type="application/vnd.apple.mpegurl" />
+      <source src={`${videoUrl}.mp4`} type="video/mp4" />
+      <source src={`${videoUrl}.webm`} type="video/webm" />
+    </Video>
+  </VideoWrapper>
+)
+
+export const BackgroundVideo: React.SFC<PlayerProps & BackgroundProps> = ({
+  videoRef,
+  mobileVideoRef,
+  desktopImage,
+  mobileImage,
+  baseVideoUrl,
+  baseMobileVideoUrl,
+  backgroundColor,
+}) => (
+  <HeightContainer backgroundColor={backgroundColor}>
+    <MediaQuery query="(max-width: 700px)">
+      {baseMobileVideoUrl ? (
+        <VideoItem videoUrl={baseMobileVideoUrl} videoRef={mobileVideoRef} />
+      ) : (
+        mobileImage && <BackgroundImage image={mobileImage} />
+      )}
+    </MediaQuery>
+    <MediaQuery query="(min-width: 701px)">
+      {baseVideoUrl ? (
+        <VideoItem videoUrl={baseVideoUrl} videoRef={videoRef} />
+      ) : (
+        desktopImage && <BackgroundImage image={desktopImage} />
+      )}
+    </MediaQuery>
+  </HeightContainer>
+)

--- a/src/blocks/ImageTextBlock/BackgroundVideo.tsx
+++ b/src/blocks/ImageTextBlock/BackgroundVideo.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import styled, { keyframes } from 'react-emotion'
 import MediaQuery from 'react-responsive'
 import { backgroundImageStyles } from '../../components/blockHelpers'
+import { DeferredVideo } from '../../components/DeferredVideo'
 
 interface BackgroundProps {
   backgroundColor: string
@@ -45,22 +46,6 @@ const VideoWrapper = styled('div')({
   position: 'relative',
 })
 
-const Video = styled('video')({
-  width: '100%',
-  objectFit: 'cover',
-  transition: 'height 1500ms',
-  overflow: 'hidden',
-  borderRadius: 0.01,
-  position: 'absolute',
-  bottom: 0,
-  right: 0,
-  left: 0,
-  height: '100%',
-  '@media(min-width: 1500px)': {
-    height: '110vh',
-  },
-})
-
 interface PlayerProps {
   videoRef: React.RefObject<HTMLVideoElement>
   mobileVideoRef: React.RefObject<HTMLVideoElement>
@@ -80,19 +65,7 @@ const VideoItem: React.FunctionComponent<VideoItemProps> = ({
   videoRef,
 }) => (
   <VideoWrapper>
-    <Video
-      poster={`${videoUrl}.png`}
-      innerRef={videoRef}
-      playsInline
-      autoPlay
-      muted={true}
-      loop={true}
-      controls={false}
-    >
-      <source src={`${videoUrl}.m3u8`} type="application/vnd.apple.mpegurl" />
-      <source src={`${videoUrl}.mp4`} type="video/mp4" />
-      <source src={`${videoUrl}.webm`} type="video/webm" />
-    </Video>
+    <DeferredVideo src={videoUrl} />
   </VideoWrapper>
 )
 

--- a/src/blocks/ImageTextBlock/index.tsx
+++ b/src/blocks/ImageTextBlock/index.tsx
@@ -169,22 +169,6 @@ const ImageVideo = styled(DeferredVideo)({
   borderRadius: 0.01,
 })
 
-const Video = styled('video')({
-  width: '100%',
-  objectFit: 'cover',
-  transition: 'height 1500ms',
-  overflow: 'hidden',
-  borderRadius: 0.01,
-  position: 'absolute',
-  bottom: 0,
-  right: 0,
-  left: 0,
-  height: '100%',
-  '@media(min-width: 1500px)': {
-    height: '110vh',
-  },
-})
-
 interface State {
   videoRef: React.RefObject<HTMLVideoElement>
   mobileVideoRef: React.RefObject<HTMLVideoElement>
@@ -376,7 +360,13 @@ export const ImageTextBlock: React.FunctionComponent<ImageTextBlockProps> = ({
                   displayOrder={media_position}
                   hasLink
                 >
-                  <ImageVideo src={image_video_file_location} />
+                  <MediaQuery query="(max-width: 700px)">
+                    <ImageVideo src={mobile_image_video_file_location} />
+                  </MediaQuery>
+
+                  <MediaQuery query="(min-width: 701px)">
+                    <ImageVideo src={image_video_file_location} />
+                  </MediaQuery>
                 </ImageVideoWrapper>
               )
             )}

--- a/src/blocks/ImageTextBlock/index.tsx
+++ b/src/blocks/ImageTextBlock/index.tsx
@@ -2,29 +2,29 @@ import { ActionMap, Container } from 'constate'
 import * as React from 'react'
 import styled from 'react-emotion'
 import MediaQuery from 'react-responsive'
+import { LinkComponent } from 'src/storyblok/StoryContainer'
+import { SectionSize } from 'src/utils/SectionSize'
+import { TextPosition } from 'src/utils/textPosition'
+import { AlignedButton } from '../../components/AlignedButton'
 import {
   ContentWrapper,
   getColorStyles,
   SectionWrapper,
   TABLET_BP_DOWN,
 } from '../../components/blockHelpers'
-import {
-  BaseBlockProps,
-  ColorComponent,
-  MarkdownHtmlComponent,
-} from '../BaseBlockProps'
-import { LinkComponent } from 'src/storyblok/StoryContainer'
-
-import { SectionSize } from 'src/utils/SectionSize'
-import { TextPosition } from 'src/utils/textPosition'
-import { AlignedButton } from '../../components/AlignedButton'
 import { buttonSizes, ButtonWeight } from '../../components/buttons'
 import { DeferredImage } from '../../components/DeferredImage'
+import { DeferredVideo } from '../../components/DeferredVideo'
 import {
   getStoryblokImage,
   getStoryblokLinkUrl,
   Image as StoryblokImage,
 } from '../../utils/storyblok'
+import {
+  BaseBlockProps,
+  ColorComponent,
+  MarkdownHtmlComponent,
+} from '../BaseBlockProps'
 import { BackgroundVideo } from './BackgroundVideo'
 
 type TitleSize = 'sm' | 'lg'
@@ -130,6 +130,7 @@ const Image = styled(DeferredImage)(
     },
   }),
 )
+
 const ImageLink = styled('a')(
   ({ displayOrder }: { displayOrder: 'top' | 'bottom' }) => ({
     display: 'inline-block',
@@ -144,6 +145,45 @@ const ImageLink = styled('a')(
     },
   }),
 )
+
+const ImageVideoWrapper = styled('div')(
+  ({
+    alignment,
+    displayOrder,
+    hasLink,
+  }: {
+    alignment: string
+    displayOrder: 'top' | 'bottom'
+    hasLink?: boolean
+  }) => ({
+    width: hasLink ? '100%' : '40%',
+    display: 'block',
+  }),
+)
+
+const ImageVideo = styled(DeferredVideo)({
+  width: '100%',
+  objectFit: 'cover',
+  transition: 'height 1500ms',
+  overflow: 'hidden',
+  borderRadius: 0.01,
+})
+
+const Video = styled('video')({
+  width: '100%',
+  objectFit: 'cover',
+  transition: 'height 1500ms',
+  overflow: 'hidden',
+  borderRadius: 0.01,
+  position: 'absolute',
+  bottom: 0,
+  right: 0,
+  left: 0,
+  height: '100%',
+  '@media(min-width: 1500px)': {
+    height: '110vh',
+  },
+})
 
 interface State {
   videoRef: React.RefObject<HTMLVideoElement>
@@ -176,9 +216,12 @@ interface ImageTextBlockProps extends BaseBlockProps {
   button_branch_link: boolean
   button_link: LinkComponent
   show_button: boolean
+  image_type: 'image' | 'video'
   image?: StoryblokImage
   use_image_link: boolean
   image_link: LinkComponent
+  image_video_file_location?: string
+  mobile_image_video_file_location?: string
   background_type: string
   background_image: string
   background_video_file_location: string
@@ -203,9 +246,12 @@ export const ImageTextBlock: React.FunctionComponent<ImageTextBlockProps> = ({
   button_branch_link,
   button_link,
   show_button,
+  image_type,
   image,
   use_image_link,
   image_link,
+  image_video_file_location,
+  mobile_image_video_file_location,
   background_type,
   background_image,
   background_video_file_location,
@@ -301,8 +347,8 @@ export const ImageTextBlock: React.FunctionComponent<ImageTextBlockProps> = ({
                 positionMobile={button_position_mobile}
               />
             </MediaQuery>
-            {image &&
-              (use_image_link ? (
+            {image && image_type !== 'video' ? (
+              use_image_link ? (
                 <ImageLink
                   href={getStoryblokLinkUrl(image_link)}
                   displayOrder={media_position}
@@ -320,7 +366,20 @@ export const ImageTextBlock: React.FunctionComponent<ImageTextBlockProps> = ({
                   displayOrder={media_position}
                   src={getStoryblokImage(image)}
                 />
-              ))}
+              )
+            ) : (
+              image_type === 'video' &&
+              image_video_file_location &&
+              mobile_image_video_file_location && (
+                <ImageVideoWrapper
+                  alignment={text_position}
+                  displayOrder={media_position}
+                  hasLink
+                >
+                  <ImageVideo src={image_video_file_location} />
+                </ImageVideoWrapper>
+              )
+            )}
           </AlignableContentWrapper>
         </SectionWrapper>
       )}

--- a/src/blocks/ImageTextBlock/index.tsx
+++ b/src/blocks/ImageTextBlock/index.tsx
@@ -179,8 +179,10 @@ interface ImageTextBlockProps extends BaseBlockProps {
   image?: StoryblokImage
   use_image_link: boolean
   image_link: LinkComponent
+  background_type: string
   background_image: string
-  background_video_url: string
+  background_video_file_location: string
+  mobile_background_video_file_location: string
   size: SectionSize
   media_position: 'top' | 'bottom'
   button_color?: ColorComponent
@@ -204,8 +206,10 @@ export const ImageTextBlock: React.FunctionComponent<ImageTextBlockProps> = ({
   image,
   use_image_link,
   image_link,
+  background_type,
   background_image,
-  background_video_url,
+  background_video_file_location,
+  mobile_background_video_file_location,
   color,
   size,
   media_position,
@@ -226,19 +230,23 @@ export const ImageTextBlock: React.FunctionComponent<ImageTextBlockProps> = ({
         <SectionWrapper
           color={color && color.color}
           size={size}
-          backgroundImage={!background_video_url ? background_image : undefined}
+          backgroundImage={
+            background_type !== 'video' ? background_image : undefined
+          }
         >
-          {background_video_url && (
-            <BackgroundVideo
-              videoRef={videoRef}
-              mobileVideoRef={mobileVideoRef}
-              desktopImage={background_video_url}
-              mobileImage={background_video_url}
-              baseVideoUrl={background_video_url}
-              baseMobileVideoUrl={background_video_url}
-              backgroundColor="standard"
-            />
-          )}
+          {background_type === 'video' &&
+            background_video_file_location &&
+            mobile_background_video_file_location && (
+              <BackgroundVideo
+                videoRef={videoRef}
+                mobileVideoRef={mobileVideoRef}
+                desktopImage={background_video_file_location}
+                mobileImage={mobile_background_video_file_location}
+                baseVideoUrl={background_video_file_location}
+                baseMobileVideoUrl={mobile_background_video_file_location}
+                backgroundColor="standard"
+              />
+            )}
 
           <AlignableContentWrapper textPosition={text_position}>
             <TextWrapper

--- a/src/blocks/SpacerBlock.tsx
+++ b/src/blocks/SpacerBlock.tsx
@@ -58,6 +58,7 @@ const padding = (overlap: boolean) => {
 const Spacer = styled(SectionWrapper)(({ overlap }: SpacerProps) => ({
   paddingBottom: '0 !important',
   position: 'relative',
+  zIndex: 1,
   ...padding(overlap),
 }))
 

--- a/src/components/DeferredVideo.tsx
+++ b/src/components/DeferredVideo.tsx
@@ -8,6 +8,10 @@ const Video = styled('video')({
   transition: 'height 1500ms',
   overflow: 'hidden',
   borderRadius: 0.01,
+  bottom: 0,
+  right: 0,
+  left: 0,
+  height: '100%',
 })
 
 interface State {

--- a/src/components/DeferredVideo.tsx
+++ b/src/components/DeferredVideo.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react'
+import styled from 'react-emotion'
+import VisibilitySensor from 'react-visibility-sensor'
+
+const Video = styled('video')({
+  width: '100%',
+  objectFit: 'cover',
+  transition: 'height 1500ms',
+  overflow: 'hidden',
+  borderRadius: 0.01,
+})
+
+interface State {
+  width?: number
+  height?: number
+  ref: React.RefObject<HTMLVideoElement>
+}
+
+const stateHasRef = (
+  state: State,
+): state is { ref: React.RefObject<HTMLVideoElement> } =>
+  Boolean(typeof state.ref === 'object' && state.ref && state.ref.current)
+
+export class DeferredVideo extends React.PureComponent<
+  React.DetailedHTMLProps<
+    React.VideoHTMLAttributes<HTMLVideoElement>,
+    HTMLVideoElement
+  >,
+  State
+> {
+  public state: State = {
+    width: undefined,
+    height: undefined,
+    ref: React.createRef<any>(),
+  }
+
+  public render() {
+    return (
+      <VisibilitySensor
+        offset={{ top: -300, bottom: -300 }}
+        partialVisibility
+        onChange={(isVisible) => {
+          if (isVisible) {
+            const refObject = stateHasRef(this.state)
+              ? this.state.ref.current
+              : null
+
+            if (refObject) {
+              refObject.addEventListener('load', this.handleSizeChange)
+              this.state.ref.current!.load()
+            }
+          }
+        }}
+      >
+        {({ isVisible }) => (
+          <Video
+            poster={`${this.props.src}.png`}
+            innerRef={this.state.ref}
+            playsInline
+            autoPlay
+            muted={true}
+            loop={true}
+            controls={false}
+          >
+            <source
+              src={isVisible ? `${this.props.src}.m3u8` : undefined}
+              type="application/vnd.apple.mpegurl"
+            />
+            <source
+              src={isVisible ? `${this.props.src}.mp4` : undefined}
+              type="video/mp4"
+            />
+            <source
+              src={isVisible ? `${this.props.src}.webm` : undefined}
+              type="video/webm"
+            />
+          </Video>
+        )}
+      </VisibilitySensor>
+    )
+  }
+
+  private handleSizeChange = () => {
+    this.setState((state) => {
+      const refObject = stateHasRef(state) ? state.ref.current : null
+      if (refObject) {
+        return {
+          height: refObject.scrollHeight,
+          width: refObject.scrollWidth,
+        }
+      }
+
+      return {}
+    })
+  }
+}

--- a/src/components/blockHelpers.tsx
+++ b/src/components/blockHelpers.tsx
@@ -124,6 +124,7 @@ export const SectionWrapper = styled('section')(
     size?: SectionSize
     backgroundImage?: string
   }) => ({
+    position: 'relative',
     ...getSectionSizeStyle(size),
     ...getColorStyles(color),
     ...backgroundImageStyles(backgroundImage),

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -1996,11 +1996,16 @@
           "required": false,
           "pos": 10
         },
+        "background_video_url": {
+          "type": "text",
+          "required": false,
+          "pos": 11
+        },
         "button_title": {
           "type": "text",
           "required": true,
           "default_value": "Default Text",
-          "pos": 11,
+          "pos": 12,
           "translatable": true
         },
         "button_type": {
@@ -2021,12 +2026,12 @@
           ],
           "required": true,
           "default_value": "filled",
-          "pos": 12
+          "pos": 13
         },
         "button_branch_link": {
           "type": "boolean",
           "description": "Create a branch link instead of the link field",
-          "pos": 13,
+          "pos": 14,
           "translatable": true
         },
         "button_link": {
@@ -2035,7 +2040,7 @@
           "display_name": "",
           "required": true,
           "default_value": "",
-          "pos": 14,
+          "pos": 15,
           "translatable": true
         },
         "media_position": {
@@ -2052,19 +2057,19 @@
           ],
           "required": true,
           "default_value": "top",
-          "pos": 15
+          "pos": 16
         },
         "show_button": {
           "type": "boolean",
           "required": false,
           "default_value": "true",
-          "pos": 16
+          "pos": 17
         },
         "button_color": {
           "field_type": "hedvig-limited-color-picker",
           "options": [],
           "type": "custom",
-          "pos": 17
+          "pos": 18
         },
         "button_size": {
           "type": "option",
@@ -2078,7 +2083,7 @@
               "name": "MD"
             }
           ],
-          "pos": 18
+          "pos": 19
         },
         "button_weight": {
           "type": "option",
@@ -2093,7 +2098,7 @@
               "name": "Bold"
             }
           ],
-          "pos": 19
+          "pos": 20
         },
         "button_position_mobile": {
           "type": "option",
@@ -2108,7 +2113,7 @@
               "name": "Below media"
             }
           ],
-          "pos": 20
+          "pos": 21
         }
       },
       "image": null,

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -1991,21 +1991,46 @@
           "translatable": true,
           "pos": 9
         },
+        "background_type": {
+          "type": "option",
+          "options": [
+            {
+              "value": "image",
+              "name": "Image"
+            },
+            {
+              "value": "video",
+              "name": "Video"
+            }
+          ],
+          "required": false,
+          "default_value": "image",
+          "pos": 10
+        },
         "background_image": {
           "type": "image",
           "required": false,
-          "pos": 10
+          "pos": 11
         },
-        "background_video_url": {
+        "background_video_file_location": {
           "type": "text",
           "required": false,
-          "pos": 11
+          "pos": 12,
+          "regex": "^https:\\/\\/",
+          "description": "Will be suffixed with /<size>.<format>, i.e. /md.png. Uploaded sizes must be: md, lg, xl, xxl. Uploaded formats must be png (for the poster), webm, mp4"
+        },
+        "mobile_background_video_file_location": {
+          "type": "text",
+          "required": false,
+          "pos": 13,
+          "regex": "^https:\\/\\/",
+          "description": "Will be suffixed with /<size>.<format>, i.e. /md.png. Uploaded sizes must be: md, lg, xl, xxl. Uploaded formats must be png (for the poster), webm, mp4"
         },
         "button_title": {
           "type": "text",
           "required": true,
           "default_value": "Default Text",
-          "pos": 12,
+          "pos": 14,
           "translatable": true
         },
         "button_type": {
@@ -2026,12 +2051,12 @@
           ],
           "required": true,
           "default_value": "filled",
-          "pos": 13
+          "pos": 15
         },
         "button_branch_link": {
           "type": "boolean",
           "description": "Create a branch link instead of the link field",
-          "pos": 14,
+          "pos": 16,
           "translatable": true
         },
         "button_link": {
@@ -2040,7 +2065,7 @@
           "display_name": "",
           "required": true,
           "default_value": "",
-          "pos": 15,
+          "pos": 17,
           "translatable": true
         },
         "media_position": {
@@ -2057,19 +2082,19 @@
           ],
           "required": true,
           "default_value": "top",
-          "pos": 16
+          "pos": 18
         },
         "show_button": {
           "type": "boolean",
           "required": false,
           "default_value": "true",
-          "pos": 17
+          "pos": 19
         },
         "button_color": {
           "field_type": "hedvig-limited-color-picker",
           "options": [],
           "type": "custom",
-          "pos": 18
+          "pos": 20
         },
         "button_size": {
           "type": "option",
@@ -2083,7 +2108,7 @@
               "name": "MD"
             }
           ],
-          "pos": 19
+          "pos": 21
         },
         "button_weight": {
           "type": "option",
@@ -2098,7 +2123,7 @@
               "name": "Bold"
             }
           ],
-          "pos": 20
+          "pos": 22
         },
         "button_position_mobile": {
           "type": "option",
@@ -2113,7 +2138,7 @@
               "name": "Below media"
             }
           ],
-          "pos": 21
+          "pos": 23
         }
       },
       "image": null,

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -1976,20 +1976,47 @@
           "default_value": "left",
           "pos": 6
         },
+        "image_type": {
+          "type": "option",
+          "options": [
+            {
+              "value": "image",
+              "name": "Image"
+            },
+            {
+              "value": "video",
+              "name": "Video"
+            }
+          ],
+          "default_value": "image",
+          "pos": 7
+        },
         "image": {
           "type": "image",
           "required": false,
-          "pos": 7
+          "pos": 8
         },
         "use_image_link": {
           "type": "boolean",
-          "pos": 8,
+          "pos": 9,
           "translatable": true
         },
         "image_link": {
           "type": "multilink",
           "translatable": true,
-          "pos": 9
+          "pos": 10
+        },
+        "image_video_file_location": {
+          "type": "text",
+          "required": false,
+          "pos": 11,
+          "description": "Will be suffixed with /<size>.<format>, i.e. /md.png. Uploaded sizes must be: md, lg, xl, xxl. Uploaded formats must be png (for the poster), webm, mp4"
+        },
+        "mobile_image_video_file_location": {
+          "type": "text",
+          "required": false,
+          "pos": 12,
+          "description": "Will be suffixed with /<size>.<format>, i.e. /md.png. Uploaded sizes must be: md, lg, xl, xxl. Uploaded formats must be png (for the poster), webm, mp4"
         },
         "background_type": {
           "type": "option",
@@ -2005,32 +2032,30 @@
           ],
           "required": false,
           "default_value": "image",
-          "pos": 10
+          "pos": 13
         },
         "background_image": {
           "type": "image",
           "required": false,
-          "pos": 11
+          "pos": 14
         },
         "background_video_file_location": {
           "type": "text",
           "required": false,
-          "pos": 12,
-          "regex": "^https:\\/\\/",
+          "pos": 15,
           "description": "Will be suffixed with /<size>.<format>, i.e. /md.png. Uploaded sizes must be: md, lg, xl, xxl. Uploaded formats must be png (for the poster), webm, mp4"
         },
         "mobile_background_video_file_location": {
           "type": "text",
           "required": false,
-          "pos": 13,
-          "regex": "^https:\\/\\/",
+          "pos": 16,
           "description": "Will be suffixed with /<size>.<format>, i.e. /md.png. Uploaded sizes must be: md, lg, xl, xxl. Uploaded formats must be png (for the poster), webm, mp4"
         },
         "button_title": {
           "type": "text",
           "required": true,
           "default_value": "Default Text",
-          "pos": 14,
+          "pos": 17,
           "translatable": true
         },
         "button_type": {
@@ -2051,12 +2076,12 @@
           ],
           "required": true,
           "default_value": "filled",
-          "pos": 15
+          "pos": 18
         },
         "button_branch_link": {
           "type": "boolean",
           "description": "Create a branch link instead of the link field",
-          "pos": 16,
+          "pos": 19,
           "translatable": true
         },
         "button_link": {
@@ -2065,7 +2090,7 @@
           "display_name": "",
           "required": true,
           "default_value": "",
-          "pos": 17,
+          "pos": 20,
           "translatable": true
         },
         "media_position": {
@@ -2082,19 +2107,19 @@
           ],
           "required": true,
           "default_value": "top",
-          "pos": 18
+          "pos": 21
         },
         "show_button": {
           "type": "boolean",
           "required": false,
           "default_value": "true",
-          "pos": 19
+          "pos": 22
         },
         "button_color": {
           "field_type": "hedvig-limited-color-picker",
           "options": [],
           "type": "custom",
-          "pos": 20
+          "pos": 23
         },
         "button_size": {
           "type": "option",
@@ -2108,7 +2133,7 @@
               "name": "MD"
             }
           ],
-          "pos": 21
+          "pos": 24
         },
         "button_weight": {
           "type": "option",
@@ -2123,7 +2148,7 @@
               "name": "Bold"
             }
           ],
-          "pos": 22
+          "pos": 25
         },
         "button_position_mobile": {
           "type": "option",
@@ -2138,7 +2163,7 @@
               "name": "Below media"
             }
           ],
-          "pos": 23
+          "pos": 26
         }
       },
       "image": null,


### PR DESCRIPTION
Extending video support by adding support for video background and "video image" in the "Image Text Block". The loading of each video is deferred until it enters the viewport, and it is dispatched when it leaves the viewport.