### PR TITLE
Add redirects for /sv and /en

### DIFF
--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -119,7 +119,8 @@ export const getPageMiddleware = (
   const routerContext: StaticRouterContext & { statusCode?: number } = {}
   const helmetContext = {}
 
-  const lang = getLangFromPath(ctx.path) || 'se'
+  const langFromPath = getLangFromPath(ctx.path)
+  const lang = langFromPath || 'se'
 
   const [story, globalStory] = await Promise.all([
     getStoryblokResponseFromContext(ctx),
@@ -132,14 +133,20 @@ export const getPageMiddleware = (
     ),
   ])
 
+  // Redirect /* to /se/*
+  if (!langFromPath && !ctx.query._storyblok) {
+    ctx.redirect(`/se${ctx.originalUrl}`)
+    return
+  }
+
   // Redirect /sv/* to /se/*
-  if (getLangFromPath(ctx.path) === 'sv' && !ctx.query._storyblok) {
+  if (langFromPath === 'sv' && !ctx.query._storyblok) {
     ctx.redirect(ctx.originalUrl.replace(/^\/sv/, '/se'))
     return
   }
 
   // Redirect /en/* to /se-en/*
-  if (getLangFromPath(ctx.path) === 'en' && !ctx.query._storyblok) {
+  if (langFromPath === 'en' && !ctx.query._storyblok) {
     ctx.redirect(ctx.originalUrl.replace(/^\/en/, '/se-en'))
     return
   }
@@ -150,7 +157,7 @@ export const getPageMiddleware = (
   }
 
   // TODO: Remove after we go live
-  if (getLangFromPath(ctx.path) === 'sv' && !ctx.query._storyblok) {
+  if (langFromPath === 'sv' && !ctx.query._storyblok) {
     ctx.redirect(ctx.originalUrl.replace(/^\/sv/, ''))
     return
   }

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -119,7 +119,7 @@ export const getPageMiddleware = (
   const routerContext: StaticRouterContext & { statusCode?: number } = {}
   const helmetContext = {}
 
-  const lang = getLangFromPath(ctx.path) || 'sv'
+  const lang = getLangFromPath(ctx.path) || 'se'
 
   const [story, globalStory] = await Promise.all([
     getStoryblokResponseFromContext(ctx),
@@ -132,11 +132,24 @@ export const getPageMiddleware = (
     ),
   ])
 
+  // Redirect /sv/* to /se/*
+  if (getLangFromPath(ctx.path) === 'sv' && !ctx.query._storyblok) {
+    ctx.redirect(ctx.originalUrl.replace(/^\/sv/, '/se'))
+    return
+  }
+
+  // Redirect /en/* to /se-en/*
+  if (getLangFromPath(ctx.path) === 'en' && !ctx.query._storyblok) {
+    ctx.redirect(ctx.originalUrl.replace(/^\/en/, '/se-en'))
+    return
+  }
+
   if (!story && !ignoreStoryblokMiss) {
     await next()
     return
   }
 
+  // TODO: Remove after we go live
   if (getLangFromPath(ctx.path) === 'sv' && !ctx.query._storyblok) {
     ctx.redirect(ctx.originalUrl.replace(/^\/sv/, ''))
     return


### PR DESCRIPTION
Make sure we catch and redirect properly. These are all the use cases I can think off

Use cases to test for /sv and /:

- [x]  / → /se
- [x]  /hemforsakring/bostadsratt → /se/hemforsakring/bostadsratt
- [x]  /sv/hemforsakring/bostadsratt → /se/hemforsakring/bostadsratt

Use cases to test for /en:

- [x]  /en → /se-en
- [x]  /en/insurance/renters → /se-en/insurance/renters